### PR TITLE
Create `att9001.gemspec`

### DIFF
--- a/att9001.gemspec
+++ b/att9001.gemspec
@@ -1,0 +1,14 @@
+Gem::Specification.new do |spec|
+  spec.name          = "att9001"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Xbony2"]
+  spec.summary       = %q{Import Minecraft language files into the tilesheet extension}
+  spec.homepage      = "https://ftb.fandom.com/wiki/Feed_The_Beast_Wiki:ATT-9001"
+  spec.license       = "MIT"
+
+  spec.files         = Dir.glob("{lib}/**/*")
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "mediawiki-butt", "~> 4.0.1"
+end
+

--- a/att9001.gemspec
+++ b/att9001.gemspec
@@ -1,14 +1,13 @@
 Gem::Specification.new do |spec|
-  spec.name          = "att9001"
-  spec.version       = "0.1.0"
-  spec.authors       = ["Xbony2"]
-  spec.summary       = %q{Import Minecraft language files into the tilesheet extension}
-  spec.homepage      = "https://ftb.fandom.com/wiki/Feed_The_Beast_Wiki:ATT-9001"
-  spec.license       = "MIT"
+	spec.name = "att9001"
+	spec.version = "1.0.0"
+	spec.authors = ["Eric Schneider (xbony2)"]
+	spec.summary = %q{Import Minecraft language files into the tilesheet extension}
+	spec.homepage = "https://github.com/FTB-Gamepedia/ATT-9001"
+	spec.license = "MIT"
 
-  spec.files         = Dir.glob("{lib}/**/*")
-  spec.require_paths = ["lib"]
+	spec.files = Dir.glob("{lib}/**/*")
+	spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mediawiki-butt", "~> 4.0.1"
+	spec.add_runtime_dependency "mediawiki-butt", "~> 4.0.1"
 end
-


### PR DESCRIPTION
This file allows you to specify certain metadata related to this Gem. This will help with publishing on rubygems.org if you take that route.

It's also needed for the NUR repository, so I figured I'd give back to the project.